### PR TITLE
Milsestone2: Setup with Dynamic Allocation User Plan

### DIFF
--- a/src/main/java/com/example/ratelimiter/config/RateLimiterConfig.java
+++ b/src/main/java/com/example/ratelimiter/config/RateLimiterConfig.java
@@ -4,13 +4,15 @@ import com.example.ratelimiter.strategy.FixedWindowStrategy;
 import com.example.ratelimiter.strategy.RateLimitingStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
 public class RateLimiterConfig {
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        // For future Redis-based strategies
+//        return null;
+//    }
 
-    @Bean
-    public RateLimitingStrategy rateLimitingStrategy() {
-        // Example: Allow 5 requests per 10 seconds
-        return new FixedWindowStrategy(5, 10);
-    }
+    // Add Prometheus/Actuator metrics beans here later
 }

--- a/src/main/java/com/example/ratelimiter/model/PlanType.java
+++ b/src/main/java/com/example/ratelimiter/model/PlanType.java
@@ -1,0 +1,28 @@
+package com.example.ratelimiter.model;
+
+public enum PlanType {
+    FREE(5, 10, "FIXED_WINDOW"),
+    PRO(100, 60, "TOKEN_BUCKET");
+
+    private final int limit;
+    private final int windowInSeconds;
+    private final String strategy;
+
+    PlanType(int limit, int windowInSeconds, String strategy) {
+        this.limit = limit;
+        this.windowInSeconds = windowInSeconds;
+        this.strategy = strategy;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public int getWindowInSeconds() {
+        return windowInSeconds;
+    }
+
+    public String getStrategy() {
+        return strategy;
+    }
+}

--- a/src/main/java/com/example/ratelimiter/model/UserPlan.java
+++ b/src/main/java/com/example/ratelimiter/model/UserPlan.java
@@ -1,0 +1,33 @@
+package com.example.ratelimiter.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserPlan {
+    private String userId;
+    private PlanType plan;
+
+    public UserPlan(String userId, PlanType plan) {
+        this.userId = userId;
+        this.plan = plan;
+    }
+
+    // Convenience getters for limits and strategy
+    public int getLimit() {
+        return plan.getLimit();
+    }
+
+    public int getWindowInSeconds() {
+        return plan.getWindowInSeconds();
+    }
+
+    public String getStrategy() {
+        return plan.getStrategy();
+    }
+
+    public String getPlanName() {
+        return plan.name();
+    }
+}

--- a/src/main/java/com/example/ratelimiter/service/UserPlanService.java
+++ b/src/main/java/com/example/ratelimiter/service/UserPlanService.java
@@ -1,0 +1,29 @@
+package com.example.ratelimiter.service;
+
+import com.example.ratelimiter.model.PlanType;
+import com.example.ratelimiter.model.UserPlan;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class UserPlanService {
+
+    private final Map<String, UserPlan> userPlanMap = new HashMap<>();
+
+    public UserPlanService() {
+        // Assign users to plans
+        userPlanMap.put("user123", new UserPlan("user123", PlanType.FREE));
+        userPlanMap.put("user999", new UserPlan("user999", PlanType.PRO));
+    }
+
+    public UserPlan getPlanForUser(String userId) {
+        UserPlan plan = userPlanMap.get(userId);
+        if (plan == null) {
+            System.out.println("User " + userId + " not found. Using Default FREE plan.");
+            return new UserPlan(userId, PlanType.FREE);
+        }
+        return plan;
+    }
+}

--- a/src/main/java/com/example/ratelimiter/strategy/FixedWindowStrategy.java
+++ b/src/main/java/com/example/ratelimiter/strategy/FixedWindowStrategy.java
@@ -1,23 +1,19 @@
 package com.example.ratelimiter.strategy;
 
+import com.example.ratelimiter.model.UserPlan;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class FixedWindowStrategy implements RateLimitingStrategy {
 
-    private final int maxRequests;
-    private final long windowInSeconds;
-
     private final Map<String, UserRequestData> userRequestMap = new ConcurrentHashMap<>();
 
-    public FixedWindowStrategy(int maxRequests, long windowInSeconds) {
-        this.maxRequests = maxRequests;
-        this.windowInSeconds = windowInSeconds;
-    }
-
     @Override
-    public boolean allowRequest(String userId) {
+    public boolean allowRequest(String userId, UserPlan plan) {
+        int maxRequests = plan.getLimit();
+        long windowInSeconds = plan.getWindowInSeconds();
         long currentWindow = Instant.now().getEpochSecond() / windowInSeconds;
 
         userRequestMap.putIfAbsent(userId, new UserRequestData(currentWindow, 0));

--- a/src/main/java/com/example/ratelimiter/strategy/RateLimitingStrategy.java
+++ b/src/main/java/com/example/ratelimiter/strategy/RateLimitingStrategy.java
@@ -1,6 +1,8 @@
 package com.example.ratelimiter.strategy;
 
+import com.example.ratelimiter.model.UserPlan;
+
 // In interfaces, all methods are public and abstract by default
 public interface  RateLimitingStrategy {
-    boolean allowRequest(String userId);
+    boolean allowRequest(String userId, UserPlan plan);
 }

--- a/src/main/java/com/example/ratelimiter/strategy/StrategyFactory.java
+++ b/src/main/java/com/example/ratelimiter/strategy/StrategyFactory.java
@@ -1,0 +1,19 @@
+package com.example.ratelimiter.strategy;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class StrategyFactory {
+
+    private final Map<String, RateLimitingStrategy> strategies = Map.of(
+            "FIXED_WINDOW", new FixedWindowStrategy(),
+            "TOKEN_BUCKET", new TokenBucketStrategy() // TODO: Implement TokenBucketStrategy
+    );
+
+    public RateLimitingStrategy getStrategy(String strategyType) {
+        // If strategyType is not found, return FixedWindowStrategy as default strategy
+        return strategies.getOrDefault(strategyType, new FixedWindowStrategy());
+    }
+}

--- a/src/main/java/com/example/ratelimiter/strategy/TokenBucketStrategy.java
+++ b/src/main/java/com/example/ratelimiter/strategy/TokenBucketStrategy.java
@@ -1,0 +1,11 @@
+package com.example.ratelimiter.strategy;
+
+import com.example.ratelimiter.model.UserPlan;
+
+public class TokenBucketStrategy implements RateLimitingStrategy {
+    @Override
+    public boolean allowRequest(String userId, UserPlan plan) {
+        // Always allow for now
+        return true;
+    }
+}


### PR DESCRIPTION
Implemented dynamic user-based rate limiting system with strategy pattern

Key Changes:
- Removed singleton RateLimiterConfig with hardcoded limits in favor of user-specific plans, kept the file for future.
- Introduced PlanType enum (FREE, PRO) to define different rate limiting tiers
- Created StrategyFactory to provide appropriate rate limiting strategy per user plan
- Implemented UserPlanService with mock user database (hardcoded for now)
- Designed RateLimitingStrategy interface with two implementations:
  * FixedWindowStrategy (implemented)
  * TokenBucketStrategy (placeholder for future implementation)
- Middleware now checks user's plan and applies corresponding rate limit strategy

System Flow:
1. Middleware extracts user ID from header
2. Fetches user's plan from UserPlanService
3. Gets appropriate strategy from StrategyFactory
4. Delegates rate limit check to strategy's allowRequest method